### PR TITLE
chore: use TypeFiche everywhere it is relevant

### DIFF
--- a/src/actions/projets/update-fiches-projet-action.ts
+++ b/src/actions/projets/update-fiches-projet-action.ts
@@ -6,12 +6,12 @@ import { updateFichesProjet } from "@/src/lib/prisma/prismaProjetQueries";
 import { ProjetWithRelations } from "@/src/lib/prisma/prismaCustomTypes";
 import { customCaptureException } from "@/src/lib/sentry/sentryCustomMessage";
 import { PermissionManager } from "@/src/helpers/permission-manager";
-import { TypeUpdate } from "@/src/helpers/common";
+import { TypeFiche, TypeUpdate } from "@/src/helpers/common";
 
 export const updateFichesProjetAction = async (
   projetId: number,
   ficheId: number,
-  typeFiche: "solution" | "diagnostic",
+  typeFiche: TypeFiche,
   typeUpdate: TypeUpdate,
 ): Promise<ResponseAction<{ projet: ProjetWithRelations | null }>> => {
   const session = await auth();
@@ -27,7 +27,8 @@ export const updateFichesProjetAction = async (
 
   try {
     const projet = await updateFichesProjet(projetId, ficheId, session.user.id, typeFiche, typeUpdate);
-    const message = typeFiche === "solution" ? "FICHE_SOLUTION_ADDED_TO_PROJET" : "FICHE_DIAGNOSTIC_ADDED_TO_PROJET";
+    const message =
+      typeFiche === TypeFiche.solution ? "FICHE_SOLUTION_ADDED_TO_PROJET" : "FICHE_DIAGNOSTIC_ADDED_TO_PROJET";
 
     return {
       type: "success",

--- a/src/actions/users/update-fiches-user-action.ts
+++ b/src/actions/users/update-fiches-user-action.ts
@@ -6,11 +6,12 @@ import { updateFichesUser } from "@/src/lib/prisma/prismaUserQueries";
 import { customCaptureException } from "@/src/lib/sentry/sentryCustomMessage";
 import { UserInfos } from "@/src/stores/user/store";
 import { PermissionManager } from "@/src/helpers/permission-manager";
+import { TypeFiche } from "@/src/helpers/common";
 
 export const updateFichesUserAction = async (
   userId: string,
   ficheId: number,
-  type: "solution" | "diagnostic",
+  type: TypeFiche,
   projectName?: string,
 ): Promise<ResponseAction<{ user: UserInfos | null }>> => {
   const session = await auth();
@@ -30,7 +31,7 @@ export const updateFichesUserAction = async (
 
     return {
       type: "success",
-      message: type === "solution" ? "BOOKMARKED_SAVED_IN_DB" : "BOOKMARKED_DIAG_SAVED_IN_DB",
+      message: type === TypeFiche.solution ? "BOOKMARKED_SAVED_IN_DB" : "BOOKMARKED_DIAG_SAVED_IN_DB",
       user,
     };
   } catch (e) {

--- a/src/components/common/generic-save-fiche/generic-save-button-authenticated-inside-projet.tsx
+++ b/src/components/common/generic-save-fiche/generic-save-button-authenticated-inside-projet.tsx
@@ -6,10 +6,10 @@ import { GenericSaveFicheButtonWithOpener } from "./generic-save-button";
 import { updateFichesProjetAction } from "@/src/actions/projets/update-fiches-projet-action";
 import { notifications } from "@/src/components/common/notifications";
 import { useCanEditProjet } from "@/src/hooks/use-can-edit-projet";
-import { TypeUpdate } from "@/src/helpers/common";
+import { TypeFiche, TypeUpdate } from "@/src/helpers/common";
 
 export const GenericSaveAuthenticatedInsideProjet = ({ opener, ...props }: GenericSaveFicheButtonWithOpener) => {
-  const isSolution = props.type === "solution";
+  const isSolution = props.type === TypeFiche.solution;
   const projet = useProjetsStore((state) => state.getCurrentProjet());
   const addOrUpdateProjet = useProjetsStore((state) => state.addOrUpdateProjet);
 

--- a/src/components/common/generic-save-fiche/generic-save-button-authenticated-outside-projet.tsx
+++ b/src/components/common/generic-save-fiche/generic-save-button-authenticated-outside-projet.tsx
@@ -4,9 +4,10 @@ import { selectSavedOrUnsavedAssets } from "./assets";
 import { GenericSaveFicheButtonWithOpener } from "./generic-save-button";
 import { isFicheBookmarked } from "./helpers";
 import { setBadgeOn, NotificationElements } from "@/src/helpers/notification-badge";
+import { TypeFiche } from "@/src/helpers/common";
 
 export const GenericSaveAuthenticatedOutsideProjet = ({ opener, ...props }: GenericSaveFicheButtonWithOpener) => {
-  const isSolution = props.type === "solution";
+  const isSolution = props.type === TypeFiche.solution;
   const userFichesSolutions = useUserStore((state) => state.userInfos?.selection_fiches_solutions) as number[];
   const userFichesDiagnostic = useUserStore((state) => state.userInfos?.selection_fiches_diagnostic) as number[];
   const currentFiches = isSolution ? userFichesSolutions : userFichesDiagnostic;

--- a/src/components/common/generic-save-fiche/generic-save-modal-authenticated-inside-projet.tsx
+++ b/src/components/common/generic-save-fiche/generic-save-modal-authenticated-inside-projet.tsx
@@ -3,12 +3,13 @@ import { GenericSaveModalCommonProps } from "./generic-save-modal";
 import Link from "next/link";
 import { PFMV_ROUTES } from "@/src/helpers/routes";
 import { GenericFicheLink } from "@/src/components/common/generic-save-fiche/generic-fiche-link";
+import { TypeFiche } from "@/src/helpers/common";
 
 export const ModalSaveModalAuthenticatedInsideProjet = ({ modal, type }: GenericSaveModalCommonProps) => {
   const projet = useProjetsStore((state) => state.getCurrentProjet());
   return (
     <modal.Component
-      title={`${type === "solution" ? "Solution" : "Méthode diagnostic"} ajoutée à mon projet`}
+      title={`${type === TypeFiche.solution ? "Solution" : "Méthode diagnostic"} ajoutée à mon projet`}
       size="medium"
       // @ts-ignore
       iconId="fr-icon-success-fill text-dsfr-background-action-high-success-hover mr-2"
@@ -18,12 +19,12 @@ export const ModalSaveModalAuthenticatedInsideProjet = ({ modal, type }: Generic
         className="fr-btn fr-btn--secondary mb-4 mr-4 !min-h-fit rounded-3xl !text-sm"
         onClick={() => modal.close()}
         href={
-          type === "diagnostic"
+          type === TypeFiche.diagnostic
             ? PFMV_ROUTES.ESPACE_PROJET_FICHES_DIAGNOSTIC_LISTE_ALL
             : PFMV_ROUTES.ESPACE_PROJET_FICHES_SOLUTION_LISTE_ALL
         }
       >
-        {type === "diagnostic" ? "Ajouter d'autres diagnostic" : "Ajouter d'autres solutions"}
+        {type === TypeFiche.diagnostic ? "Ajouter d'autres diagnostic" : "Ajouter d'autres solutions"}
       </GenericFicheLink>
       <Link href={PFMV_ROUTES.TABLEAU_DE_BORD(projet?.id!)} className="fr-btn mr-4 !min-h-fit rounded-3xl !text-sm">
         Aller au tableau de bord

--- a/src/components/common/generic-save-fiche/generic-save-modal-authenticated-outside-projet.tsx
+++ b/src/components/common/generic-save-fiche/generic-save-modal-authenticated-outside-projet.tsx
@@ -11,7 +11,7 @@ import { Hidden } from "../hidden";
 import { NotificationElements, setBadgeOff } from "@/src/helpers/notification-badge";
 import { updateFichesProjetAction } from "@/src/actions/projets/update-fiches-projet-action";
 import { notifications } from "@/src/components/common/notifications";
-import { TypeUpdate } from "@/src/helpers/common";
+import { TypeFiche, TypeUpdate } from "@/src/helpers/common";
 
 export const ModalSaveModalAuthenticatedOutsideProjet = ({
   modal,
@@ -42,15 +42,15 @@ export const ModalSaveModalAuthenticatedOutsideProjet = ({
         <div className="mb-4 mt-6 flex items-center">
           <i className={"fr-icon--lg fr-icon-arrow-right-line mr-4"} />
           <span className="block text-2xl font-bold">
-            {type === "solution" ? "Solution" : "Méthode de diagnostic"} ajoutée dans Ma sélection
+            {type === TypeFiche.solution ? "Solution" : "Méthode de diagnostic"} ajoutée dans Ma sélection
           </span>
         </div>
       }
       size="large"
     >
       <span>
-        Retrouvez toutes vos {type === "solution" ? "solutions" : "méthode de diagnostic"} mises en favoris dans Ma
-        sélection. <br />
+        Retrouvez toutes vos {type === TypeFiche.solution ? "solutions" : "méthode de diagnostic"} mises en favoris dans
+        Ma sélection. <br />
         Voulez-vous ajouter aussi cette solution dans l’un de vos projets ?
       </span>
       <div className="my-10 flex flex-col gap-0 md:flex-row md:items-center md:gap-5">
@@ -91,10 +91,10 @@ export const ModalSaveModalAuthenticatedOutsideProjet = ({
           modal.close();
           setBadgeOff(NotificationElements.selectionMenuItem);
         }}
-        href={type === "solution" ? PFMV_ROUTES.MES_FICHES_SOLUTIONS : PFMV_ROUTES.MES_FICHES_SOLUTIONS}
+        href={type === TypeFiche.solution ? PFMV_ROUTES.MES_FICHES_SOLUTIONS : PFMV_ROUTES.MES_FICHES_SOLUTIONS}
         className="fr-btn fr-btn--secondary mr-4 !min-h-fit rounded-3xl !text-sm"
       >
-        Voir mes {type === "solution" ? "fiches solutions" : "fiches diagnostic"}
+        Voir mes {type === TypeFiche.solution ? "fiches solutions" : "fiches diagnostic"}
       </Link>
     </modal.Component>
   );

--- a/src/components/common/generic-save-fiche/generic-save-modal-unauthenticated.tsx
+++ b/src/components/common/generic-save-fiche/generic-save-modal-unauthenticated.tsx
@@ -2,9 +2,10 @@ import { PFMV_ROUTES } from "@/src/helpers/routes";
 import Button from "@codegouvfr/react-dsfr/Button";
 import { GenericSaveModalCommonProps } from "./generic-save-modal";
 import { setBadgeOff, NotificationElements } from "@/src/helpers/notification-badge";
+import { TypeFiche } from "@/src/helpers/common";
 
 export const GenericSaveModalUnauthenticated = ({ modal, type }: GenericSaveModalCommonProps) => {
-  const isSolution = type === "solution";
+  const isSolution = type === TypeFiche.solution;
   const mention = isSolution ? "Solution" : "Méthode diagnostic";
   const mentions = isSolution ? "solutions" : "méthodes diagnostic";
   return (

--- a/src/components/common/generic-save-fiche/generic-save-modal.tsx
+++ b/src/components/common/generic-save-fiche/generic-save-modal.tsx
@@ -4,10 +4,11 @@ import { useProjetsStore } from "@/src/stores/projets/provider";
 import { ModalSaveModalAuthenticatedOutsideProjet } from "./generic-save-modal-authenticated-outside-projet";
 import { ModalSaveModalAuthenticatedInsideProjet } from "./generic-save-modal-authenticated-inside-projet";
 import { useSession } from "next-auth/react";
+import { TypeFiche } from "@/src/helpers/common";
 
 export type GenericSaveModalCommonProps = {
   modal: DSFRModal;
-  type: "solution" | "diagnostic";
+  type: TypeFiche;
   id: number;
 };
 

--- a/src/components/common/generic-save-fiche/helpers.ts
+++ b/src/components/common/generic-save-fiche/helpers.ts
@@ -1,3 +1,5 @@
+import { TypeFiche } from "@/src/helpers/common";
+
 export const BOOKMARK_FS_KEY = "bookmark-fs-id";
 export const FICHE_DIAGNOSTIC_IDS_STORAGE_KEY = "fiches-diagnostic";
 export type FicheBookmarkedSolution = {
@@ -26,14 +28,14 @@ export const isFicheBookmarked = (
 };
 
 export const addFicheBookmark = (
-  type: "solution" | "diagnostic",
+  type: TypeFiche,
   currentBookmarks: FichesBookmarked[],
   ficheId: number | undefined,
   projectName: string,
 ): FichesBookmarked[] => {
   if (!ficheId) return currentBookmarks;
 
-  if (type === "diagnostic") {
+  if (type === TypeFiche.diagnostic) {
     if (!currentBookmarks.includes(+ficheId)) {
       currentBookmarks.push(+ficheId);
     }
@@ -56,14 +58,14 @@ export const addFicheBookmark = (
 };
 
 export const deleteBookmarkFiche = (
-  type: "solution" | "diagnostic",
+  type: TypeFiche,
   currentBookmarks: FichesBookmarked[],
   ficheId: number | undefined,
   projectName: string,
 ): FichesBookmarked[] => {
   if (!ficheId) return currentBookmarks;
 
-  if (type === "diagnostic") {
+  if (type === TypeFiche.diagnostic) {
     return currentBookmarks.filter((bookmark) => bookmark !== +ficheId);
   } else {
     const updatedBookmarks = currentBookmarks.map((bookmark) => {

--- a/src/components/common/generic-save-fiche/index.tsx
+++ b/src/components/common/generic-save-fiche/index.tsx
@@ -3,11 +3,11 @@
 import { createModal } from "@codegouvfr/react-dsfr/Modal";
 import { GenericSaveModal } from "./generic-save-modal";
 import { GenericSaveButton } from "./generic-save-button";
-import { generateRandomId } from "@/src/helpers/common";
+import { generateRandomId, TypeFiche } from "@/src/helpers/common";
 import clsx from "clsx";
 
 export type GenericSaveBaseProps = {
-  type: "diagnostic" | "solution";
+  type: TypeFiche;
   id: number;
   projectName?: string;
   withLabel?: boolean;

--- a/src/components/common/generic-save-fiche/use-fiche-local-storage.tsx
+++ b/src/components/common/generic-save-fiche/use-fiche-local-storage.tsx
@@ -1,8 +1,9 @@
 import { useLocalStorage } from "usehooks-ts";
 import { FichesBookmarked, BOOKMARK_FS_KEY, FICHE_DIAGNOSTIC_IDS_STORAGE_KEY } from "./helpers";
+import { TypeFiche } from "@/src/helpers/common";
 
-export const useFicheLocalStorage = (type: "solution" | "diagnostic") => {
-  const isSolution = type === "solution";
+export const useFicheLocalStorage = (type: TypeFiche) => {
+  const isSolution = type === TypeFiche.solution;
   const [fichesInStorage, setFichesInStorage] = useLocalStorage<FichesBookmarked[]>(
     isSolution ? BOOKMARK_FS_KEY : FICHE_DIAGNOSTIC_IDS_STORAGE_KEY,
     [],

--- a/src/components/common/generic-save-fiche/use-save-bookmarks.ts
+++ b/src/components/common/generic-save-fiche/use-save-bookmarks.ts
@@ -1,8 +1,9 @@
 import { useState, useEffect } from "react";
 import { FichesBookmarked, isFicheBookmarked, deleteBookmarkFiche, addFicheBookmark } from "./helpers";
+import { TypeFiche } from "@/src/helpers/common";
 
 export const useSaveBookmarks = (
-  type: "solution" | "diagnostic",
+  type: TypeFiche,
   ficheId: number,
   fichesInStorage: FichesBookmarked[],
   setFichesInStorage: (_fichesInStorage: FichesBookmarked[]) => void,

--- a/src/components/ficheSolution/FicheSolutionCardWithUserInfo.tsx
+++ b/src/components/ficheSolution/FicheSolutionCardWithUserInfo.tsx
@@ -4,6 +4,7 @@ import { PropsWithChildren } from "react";
 import FicheSolutionFullCard from "@/src/components/ficheSolution/fiche-solution-full-card";
 import { GenericSaveFiche } from "../common/generic-save-fiche";
 import { FicheSolution } from "@/src/lib/strapi/types/api/fiche-solution";
+import { TypeFiche } from "@/src/helpers/common";
 
 export type FicheSolutionCardWithUserInfoProps = {
   ficheSolution: FicheSolution;
@@ -27,7 +28,7 @@ export default function FicheSolutionCardWithUserInfo({
       {children}
       <GenericSaveFiche
         id={ficheSolution.id}
-        type="solution"
+        type={TypeFiche.solution}
         projectName={projectName}
         withoutModal={withoutModal}
         classNameButton="absolute top-3 right-4"

--- a/src/components/ficheSolution/fiche-solution.tsx
+++ b/src/components/ficheSolution/fiche-solution.tsx
@@ -14,6 +14,7 @@ import { getAideDecisionHistoryBySlug } from "@/src/lib/strapi/queries/aideDecis
 import clsx from "clsx";
 import ButtonShareCurrentUrl from "@/src/components/common/button-share-current-url";
 import { GenericSaveFiche } from "../common/generic-save-fiche";
+import { TypeFiche } from "@/src/helpers/common";
 
 export async function FicheSolution({
   params,
@@ -62,14 +63,14 @@ export async function FicheSolution({
             <div className="absolute right-4 top-[68px] md:hidden">
               <GenericSaveFiche
                 id={ficheSolution.id}
-                type="solution"
+                type={TypeFiche.solution}
                 projectName={(historique && historique[1].label) || ""}
               />
             </div>
             <div className="mt-4 hidden md:block">
               <GenericSaveFiche
                 id={ficheSolution.id}
-                type="solution"
+                type={TypeFiche.solution}
                 projectName={(historique && historique[1].label) || ""}
                 withLabel
               />

--- a/src/components/fiches-diagnostic/fiche-diagnostic-card.tsx
+++ b/src/components/fiches-diagnostic/fiche-diagnostic-card.tsx
@@ -29,7 +29,7 @@ export const FicheDiagnosticCard = ({ ficheDiagnostic, vertical }: FicheDiagnost
 
   return (
     <div className={clsx("pfmv-card relative h-auto w-72", !vertical && "lg:h-fit lg:w-full lg:max-w-[53rem]")}>
-      <GenericSaveFiche id={ficheDiagnostic.id} type="diagnostic" classNameButton="absolute top-3 right-4" />
+      <GenericSaveFiche id={ficheDiagnostic.id} type={TypeFiche.diagnostic} classNameButton="absolute top-3 right-4" />
       <GenericFicheLink href={ficheUrl}>
         <div
           className={clsx(

--- a/src/components/fiches-diagnostic/fiche-diagnostic-tabs.tsx
+++ b/src/components/fiches-diagnostic/fiche-diagnostic-tabs.tsx
@@ -7,6 +7,7 @@ import { FicheDiagnosticMiseEnOeuvreTab } from "./fiche-diagnostic-tab-meo";
 import ButtonShareCurrentUrl from "@/src/components/common/button-share-current-url";
 import { GenericSaveFiche } from "../common/generic-save-fiche";
 import { FicheDiagnostic } from "@/src/lib/strapi/types/api/fiche-diagnostic";
+import { TypeFiche } from "@/src/helpers/common";
 
 type FicheDiagnosticTabsProps = {
   ficheDiagnostic: FicheDiagnostic;
@@ -42,10 +43,10 @@ export const FicheDiagnosticTabs = ({ ficheDiagnostic }: FicheDiagnosticTabsProp
           <ButtonShareCurrentUrl className={"hidden md:block [&>*]:mb-2"} />
 
           <div className="absolute right-4 top-[68px] md:hidden">
-            <GenericSaveFiche id={id} type="diagnostic" />
+            <GenericSaveFiche id={id} type={TypeFiche.diagnostic} />
           </div>
           <div className="mt-4 hidden md:block">
-            <GenericSaveFiche id={id} type="diagnostic" withLabel />
+            <GenericSaveFiche id={id} type={TypeFiche.diagnostic} withLabel />
           </div>
         </div>
         <div className="fr-tabs !shadow-none before:!shadow-none">

--- a/src/helpers/common.tsx
+++ b/src/helpers/common.tsx
@@ -11,9 +11,9 @@ export const scrollToTop = (element?: string) => {
 
 export enum TypeFiche {
   // eslint-disable-next-line no-unused-vars
-  solution,
+  solution = "solution",
   // eslint-disable-next-line no-unused-vars
-  diagnostic,
+  diagnostic = "diagnostic",
 }
 
 export enum TypeUpdate {

--- a/src/lib/prisma/prismaProjetQueries.ts
+++ b/src/lib/prisma/prismaProjetQueries.ts
@@ -1,7 +1,7 @@
 import { prismaClient } from "@/src/lib/prisma/prismaClient";
 import { emailType, InvitationStatus, Prisma, projet, RoleProjet, user_projet } from "@prisma/client";
 import { ProjetWithPublicRelations, ProjetWithRelations } from "./prismaCustomTypes";
-import { generateRandomId, TypeUpdate } from "@/src/helpers/common";
+import { generateRandomId, TypeFiche, TypeUpdate } from "@/src/helpers/common";
 import { GeoJsonProperties } from "geojson";
 import { RexContactId } from "@/src/components/sourcing/types";
 
@@ -84,11 +84,12 @@ export const updateFichesProjet = async (
   projetId: number,
   ficheId: number,
   userId: string,
-  type: "solution" | "diagnostic",
+  type: TypeFiche,
   typeUpdate: TypeUpdate,
 ): Promise<ProjetWithRelations | null> => {
   const projet = await getProjetById(projetId);
-  const selectedFichesInProjet = type === "solution" ? projet?.fiches_solutions_id : projet?.fiches_diagnostic_id;
+  const selectedFichesInProjet =
+    type === TypeFiche.solution ? projet?.fiches_solutions_id : projet?.fiches_diagnostic_id;
   const recommandationsViewedUserIds = projet?.recommandations_viewed_by;
   let updatedRecommandationsViewed: string[] = [];
 
@@ -106,8 +107,8 @@ export const updateFichesProjet = async (
       id: projetId,
     },
     data: {
-      fiches_solutions_id: type === "solution" ? fichesUpdated : projet?.fiches_solutions_id,
-      fiches_diagnostic_id: type === "diagnostic" ? fichesUpdated : projet?.fiches_diagnostic_id,
+      fiches_solutions_id: type === TypeFiche.solution ? fichesUpdated : projet?.fiches_solutions_id,
+      fiches_diagnostic_id: type === TypeFiche.diagnostic ? fichesUpdated : projet?.fiches_diagnostic_id,
       recommandations_viewed_by: updatedRecommandationsViewed,
     },
     include: projetIncludes,

--- a/src/lib/prisma/prismaUserQueries.ts
+++ b/src/lib/prisma/prismaUserQueries.ts
@@ -11,6 +11,7 @@ import { prismaClient } from "@/src/lib/prisma/prismaClient";
 import { UserWithCollectivite, UserWithProjets } from "@/src/lib/prisma/prismaCustomTypes";
 import { Prisma, User } from "@prisma/client";
 import { IApiSirenQueryTypes } from "@/src/lib/siren/types";
+import { TypeFiche } from "@/src/helpers/common";
 
 export const saveAllFichesFromLocalStorage = async (
   userId: string,
@@ -46,15 +47,10 @@ export const saveAllFichesFromLocalStorage = async (
   });
 };
 
-export const updateFichesUser = async (
-  ficheId: number,
-  userId: string,
-  type: "solution" | "diagnostic",
-  projectName?: string,
-) => {
+export const updateFichesUser = async (ficheId: number, userId: string, type: TypeFiche, projectName?: string) => {
   const user = await getUserWithCollectivites(userId);
   const selectedByUser =
-    type === "solution"
+    type === TypeFiche.solution
       ? (user?.selection_fiches_solutions as number[])
       : (user?.selection_fiches_diagnostic as number[]);
 
@@ -69,9 +65,10 @@ export const updateFichesUser = async (
       id: userId,
     },
     data: {
-      selection_fiches_solutions: type === "solution" ? fichesUpdated : (user?.selection_fiches_solutions as number[]),
+      selection_fiches_solutions:
+        type === TypeFiche.solution ? fichesUpdated : (user?.selection_fiches_solutions as number[]),
       selection_fiches_diagnostic:
-        type === "diagnostic" ? (fichesUpdated as number[]) : (user?.selection_fiches_diagnostic as number[]),
+        type === TypeFiche.diagnostic ? (fichesUpdated as number[]) : (user?.selection_fiches_diagnostic as number[]),
     },
     include: { collectivites: { include: { collectivite: true } } },
   });

--- a/src/stores/user/store.ts
+++ b/src/stores/user/store.ts
@@ -8,6 +8,7 @@ import {
 } from "@/src/components/common/generic-save-fiche/helpers";
 import { updateFichesUserAction } from "@/src/actions/users/update-fiches-user-action";
 import { saveAllFichesFromLocalStorageAction } from "@/src/actions/users/save-all-fiches-from-local-storage";
+import { TypeFiche } from "@/src/helpers/common";
 
 export type UserInfos = UserWithCollectivite | null | undefined;
 
@@ -22,7 +23,7 @@ export type UserActions = {
   setBookmarkedFichesSolutions: (_bookmarkedFichesSolutions: FicheBookmarkedSolution[]) => void;
   setBookmarkedFichesDiagnostic: (_bookmarkedFichesDiagnostic: string[]) => void;
   updateBookmarkedFichesSolutions: (_bookmarkedFichesSolutions: FichesBookmarked[]) => void;
-  updateFichesUser: (_type: "solution" | "diagnostic", _ficheId: number, _projectName: string) => void;
+  updateFichesUser: (_type: TypeFiche, _ficheId: number, _projectName: string) => void;
   updateBookmarkedFichesFromLocalStorage: () => void;
 };
 


### PR DESCRIPTION
Petite PR sans ticket associé, juste pour ne plus utiliser "solution" | "diagnostic", mais plutôt l'énum "TypeFiche